### PR TITLE
fix: Delete temporary file when scanner exits

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@ pythonPackages.buildPythonPackage rec {
   src = ./.;
   updateCpedict = import ./scripts/cpedict/update-cpedict.nix { pkgs=pkgs; };
   makeWrapperArgs = [
-    "--prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nix pkgs.graphviz updateCpedict ]}"
+    "--prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nix pkgs.graphviz updateCpedict pkgs.curl pkgs.gzip ]}"
   ];
 
   propagatedBuildInputs = [ 

--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,7 @@ pythonPackages.buildPythonPackage rec {
     pythonPackages.graphviz
     pythonPackages.numpy
     pythonPackages.packageurl-python
+    pythonPackages.packaging
     pythonPackages.pandas
     pythonPackages.requests
     pythonPackages.tabulate

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "lastModified": 1685836261,
+        "narHash": "sha256-rpxEPGeW4JZJcH58SQApJUtJ7w78VPtkF6Cut/Pq6Kg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "rev": "dd4982554e18b936790da07c4ea2db7c7600f283",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680669251,
-        "narHash": "sha256-AVNE+0u4HlI3v96KCXE9risH7NKqj0QDLLfSckYXIbA=",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9c8ff8b426a8b07b9e0a131ac3218740dc85ba1e",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
         "type": "github"
       },
       "original": {

--- a/nixgraph/graph.py
+++ b/nixgraph/graph.py
@@ -11,12 +11,14 @@
 
 import os
 import re
+import sys
 import logging
 import html
 from dataclasses import dataclass
 import pandas as pd
 import graphviz as gv
 
+from sbomnix.nix import find_deriver
 from sbomnix.utils import (
     LOGGER_NAME,
     LOG_SPAM,
@@ -278,16 +280,10 @@ class NixDependencies:
 
     def _parse_buildtime_dependencies(self, nix_path):
         # map nix_path to derivation path by calling nix path-info
-        nix_drv = exec_cmd(
-            [
-                "nix",
-                "--extra-experimental-features",
-                "nix-command",
-                "path-info",
-                "--derivation",
-                nix_path,
-            ]
-        ).strip()
+        nix_drv = find_deriver(nix_path)
+        if not nix_drv:
+            _LOG.fatal(f"Couldn't find deriver for path `{nix_path}`")
+            sys.exit(1)
         _LOG.debug("nix_drv: %s", nix_drv)
         self.start_path = nix_drv
         self.nix_store_path = _get_nix_store_path(self.start_path)

--- a/scripts/vulnxscan/vulnxscan.py
+++ b/scripts/vulnxscan/vulnxscan.py
@@ -288,7 +288,7 @@ def _generate_sbom(target_path, buildtime=False):
     sbomdb = SbomDb(target_path, runtime, buildtime, meta_path=None)
     prefix = "vulnxscan_"
     suffix = ".json"
-    with NamedTemporaryFile(delete=False, prefix=prefix, suffix=suffix) as f:
+    with NamedTemporaryFile(delete=True, prefix=prefix, suffix=suffix) as f:
         sbomdb.to_cdx(f.name, printinfo=False)
         return f.name
 


### PR DESCRIPTION
This file wasn't being cleaned up, resulting in 32k left on the filesystem after every scan. The actual result is conveyed in the file specified by `--out`, so we don't actually need this temp file to persist.